### PR TITLE
[MAT-7966] Use DataRequirementsProcessor to build Include Libraries Data Requirements

### DIFF
--- a/src/main/java/gov/cms/mat/cql_elm_translation/service/EffectiveDataRequirementService.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/service/EffectiveDataRequirementService.java
@@ -7,14 +7,18 @@ import gov.cms.madie.cql_elm_translator.utils.cql.cql_translator.TranslationReso
 import gov.cms.madie.cql_elm_translator.utils.cql.data.RequestData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.cqframework.cql.cql2elm.CqlCompilerOptions;
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.LibraryBuilder;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.model.CompiledLibrary;
 import org.cqframework.cql.elm.requirements.fhir.DataRequirementsProcessor;
+import org.hl7.elm.r1.ExpressionDef;
 import org.springframework.stereotype.Service;
 import gov.cms.madie.cql_elm_translator.service.CqlLibraryService;
+
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -63,6 +67,15 @@ public class EffectiveDataRequirementService {
     CqlCompilerOptions options = CqlCompilerOptions.defaultOptions();
     options.setCollapseDataRequirements(true); // removing duplicate data requirements
     options.setSignatureLevel(LibraryBuilder.SignatureLevel.Overloads);
+
+    // null indicates Included Library, pass all CQL Definitions to DataRequirementsProcessor
+    if (libraryDetails.getExpressions() == null) {
+      libraryDetails.setExpressions(
+          translatedLibrary.getLibrary().getStatements().getDef().stream()
+              .map(ExpressionDef::getName)
+              .filter(defName -> !StringUtils.equalsIgnoreCase(defName, "patient"))
+              .collect(Collectors.toSet()));
+    }
 
     org.hl7.fhir.r5.model.Library effectiveDataRequirements =
         dqReqTrans.gatherDataRequirements(


### PR DESCRIPTION
## CQL to ELM Translation Service PR

Jira Ticket: [MAT-7966](https://jira.cms.gov/browse/MAT-7966)
(Optional) Related Tickets:

### Summary
Use DataRequirementsProcessor to build Include Libraries Data Requirements to typecast QICore/USCore Profile types to their FHIR relative. E.g., "QICore Simple Observation" -> "Observation". 

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
