### PR TITLE
MAT-9465: update effective data requirements to use NpmModelInfoProvider via CqlConversionService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-translator-commons</artifactId>
-      <version>2.1.6-SNAPSHOT</version>
+      <version>2.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>gov.cms.madie</groupId>

--- a/src/main/java/gov/cms/mat/cql_elm_translation/service/CqlConversionService.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/service/CqlConversionService.java
@@ -3,6 +3,7 @@ package gov.cms.mat.cql_elm_translation.service;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 
+import gov.cms.madie.cql_elm_translator.utils.cql.cql_translator.TranslationResource;
 import gov.cms.madie.models.dto.TranslatedLibrary;
 import gov.cms.mat.cql.dto.CqlConversionPayload;
 import gov.cms.madie.cql_elm_translator.utils.MadieCqlValidator;
@@ -151,6 +152,13 @@ public class CqlConversionService extends CqlTooling {
       return null;
     }
     return super.processCqlData(requestData);
+  }
+
+  public TranslationResource getTranslationResource(RequestData requestData) {
+    if (requestData == null || StringUtils.isBlank(requestData.getCqlData())) {
+      return null;
+    }
+    return super.getTranslationResource(requestData);
   }
 
   public TranslatedLibrary buildTranslatedLibrary(

--- a/src/main/java/gov/cms/mat/cql_elm_translation/service/CqlTooling.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/service/CqlTooling.java
@@ -116,6 +116,11 @@ public abstract class CqlTooling {
   }
 
   protected CqlTranslator processCqlData(RequestData requestData) {
+    TranslationResource translationResource = getTranslationResource(requestData);
+    return translationResource.buildTranslator(requestData);
+  }
+
+  protected TranslationResource getTranslationResource(RequestData requestData) {
     CqlTextParser cqlTextParser = new CqlTextParser(requestData.getCqlData());
     UsingProperties usingProperties =
         fhirUtil.getMostSpecificFhirModel(cqlTextParser.getAllUsings());
@@ -129,9 +134,9 @@ public abstract class CqlTooling {
               .withId(usingProperties.getLibraryType())
               .withVersion(usingProperties.getVersion());
       ModelManager modelManager = modelManagerFactory.getModelManager(modelIdentifier);
-      return TranslationResource.getInstance(modelManager, true).buildTranslator(requestData);
+      return new TranslationResource(modelManager, true);
     } else {
-      return TranslationResource.getInstance(true).buildTranslator(requestData);
+      return new TranslationResource(true);
     }
   }
 

--- a/src/main/java/gov/cms/mat/cql_elm_translation/service/EffectiveDataRequirementService.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/service/EffectiveDataRequirementService.java
@@ -3,7 +3,6 @@ package gov.cms.mat.cql_elm_translation.service;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import gov.cms.madie.cql_elm_translator.dto.CqlLibraryDetails;
-import gov.cms.madie.cql_elm_translator.utils.cql.cql_translator.TranslationResource;
 import gov.cms.madie.cql_elm_translator.utils.cql.data.RequestData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +25,7 @@ import static org.cqframework.cql.elm.requirements.fhir.utilities.SpecificationL
 public class EffectiveDataRequirementService {
   private final FhirContext fhirContextForR5;
   private final CqlLibraryService cqlLibraryService;
+  private final CqlConversionService cqlConversionService;
 
   private RequestData createDefaultRequestData(String cql) {
     return RequestData.builder()
@@ -58,9 +58,8 @@ public class EffectiveDataRequirementService {
 
     // setting up the librarySourceProvider to fetch included libraries
     cqlLibraryService.setUpLibrarySourceProvider(libraryDetails.getCql(), accessToken);
-
-    var translationResource = TranslationResource.getInstance(true);
     RequestData requestData = createDefaultRequestData(libraryDetails.getCql());
+    var translationResource = cqlConversionService.getTranslationResource(requestData);
     CqlTranslator cqlTranslator = translationResource.buildTranslator(requestData);
     CompiledLibrary translatedLibrary = cqlTranslator.getTranslatedLibrary();
     LibraryManager libraryManager = translationResource.getLibraryManager();

--- a/src/test/java/gov/cms/mat/cql_elm_translation/service/CqlConversionServiceTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/service/CqlConversionServiceTest.java
@@ -8,6 +8,7 @@ import gov.cms.mat.cql.CqlTextParser;
 import gov.cms.mat.cql.dto.CqlConversionPayload;
 import gov.cms.mat.cql_elm_translation.ResourceFileUtil;
 import gov.cms.madie.cql_elm_translator.utils.cql.cql_translator.MadieLibrarySourceProvider;
+import gov.cms.madie.cql_elm_translator.utils.cql.cql_translator.TranslationResource;
 import gov.cms.madie.cql_elm_translator.utils.cql.data.RequestData;
 import gov.cms.madie.cql_elm_translator.exceptions.InternalServerException;
 import gov.cms.mat.cql_elm_translation.exceptions.UnsupportedModelException;
@@ -95,6 +96,42 @@ class CqlConversionServiceTest implements ResourceFileUtil {
     lenient()
         .when(modelManagerFactory.getModelManager(any(ModelIdentifier.class)))
         .thenReturn(mock(ModelManager.class));
+  }
+
+  @Test
+  void testGetTranslationResourceReturnsNullForNullRequestData() {
+    // given
+    RequestData nullRequestData = null;
+
+    // when
+    TranslationResource result = service.getTranslationResource(nullRequestData);
+
+    // then
+    assertThat(result, is(equalTo(null)));
+  }
+
+  @Test
+  void testGetTranslationResourceReturnsNullForNullCql() {
+    // given
+    RequestData requestDataWithNullCql = requestData.toBuilder().cqlData(null).build();
+
+    // when
+    TranslationResource result = service.getTranslationResource(requestDataWithNullCql);
+
+    // then
+    assertThat(result, is(equalTo(null)));
+  }
+
+  @Test
+  void testGetTranslationResourceReturnsNullForEmptyCql() {
+    // given
+    RequestData requestDataWithEmptyCql = requestData.toBuilder().cqlData("").build();
+
+    // when
+    TranslationResource result = service.getTranslationResource(requestDataWithEmptyCql);
+
+    // then
+    assertThat(result, is(equalTo(null)));
   }
 
   @Test

--- a/src/test/java/gov/cms/mat/cql_elm_translation/service/EffectiveDataRequirementServiceTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/service/EffectiveDataRequirementServiceTest.java
@@ -6,16 +6,26 @@ import gov.cms.madie.cql_elm_translator.dto.CqlLibraryDetails;
 import gov.cms.mat.cql.CqlTextParser;
 import gov.cms.madie.cql_elm_translator.service.CqlLibraryService;
 import gov.cms.madie.cql_elm_translator.utils.cql.cql_translator.MadieLibrarySourceProvider;
+import gov.cms.madie.cql_elm_translator.utils.cql.cql_translator.TranslationResource;
 import gov.cms.madie.cql_elm_translator.utils.ResourceUtils;
 
+import org.cqframework.cql.cql2elm.CqlTranslator;
+import org.cqframework.cql.cql2elm.LibraryManager;
+import org.cqframework.cql.cql2elm.model.CompiledLibrary;
+import org.hl7.elm.r1.ExpressionDef;
+import org.hl7.elm.r1.Library;
+import org.hl7.elm.r1.VersionedIdentifier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,12 +35,23 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class EffectiveDataRequirementServiceTest {
 
   @Mock FhirContext fhirContextForR5;
   @Mock CqlLibraryService cqlLibraryService;
   @Mock JsonParser r5Parser;
   @Mock JsonParser jsonParserPrettier;
+  @Mock CqlConversionService cqlConversionService;
+  @Mock TranslationResource translationResource;
+  @Mock CqlTranslator cqlTranslator;
+  @Mock LibraryManager libraryManager;
+  @Mock CompiledLibrary compiledLibrary;
+  @Mock Library elmLibrary;
+  @Mock VersionedIdentifier versionedIdentifier;
+  @Mock Library.Usings usings;
+  @Mock Library.Statements statements;
+  @Mock ExpressionDef expressionDef;
 
   @InjectMocks EffectiveDataRequirementService effectiveDataRequirementService;
 
@@ -69,11 +90,28 @@ class EffectiveDataRequirementServiceTest {
         .when(cqlLibraryService)
         .getLibraryCql(eq("TestCVPopulations"), nullable(String.class), nullable(String.class));
 
+    // Mock TranslationResource dependencies
+    when(cqlConversionService.getTranslationResource(any())).thenReturn(translationResource);
+    when(translationResource.buildTranslator(any())).thenReturn(cqlTranslator);
+    when(translationResource.getLibraryManager()).thenReturn(libraryManager);
+    when(cqlTranslator.getTranslatedLibrary()).thenReturn(compiledLibrary);
+    when(cqlTranslator.getTranslatedLibraries()).thenReturn(new ConcurrentHashMap<>());
+    when(compiledLibrary.getIdentifier()).thenReturn(versionedIdentifier);
+    when(libraryManager.getCompiledLibraries()).thenReturn(new ConcurrentHashMap<>());
+    when(compiledLibrary.getLibrary()).thenReturn(elmLibrary);
+
+    // Mock Library internals
+    when(elmLibrary.getUsings()).thenReturn(usings);
+    when(usings.getDef()).thenReturn(java.util.List.of());
+    when(elmLibrary.getStatements()).thenReturn(statements);
+    when(statements.getDef()).thenReturn(java.util.List.of());
+    when(elmLibrary.getIncludes()).thenReturn(null);
+
     MadieLibrarySourceProvider.setCqlLibraryService(cqlLibraryService);
     org.hl7.fhir.r5.model.Library r5Library =
         effectiveDataRequirementService.getEffectiveDataRequirements(
             cqlLibraryDetails, false, testAccessToken);
-    assertEquals(r5Library.getId(), "effective-data-requirements");
+    assertEquals("effective-data-requirements", r5Library.getId());
   }
 
   @Test
@@ -96,6 +134,23 @@ class EffectiveDataRequirementServiceTest {
         .when(cqlLibraryService)
         .getLibraryCql(eq("TestCVPopulations"), nullable(String.class), nullable(String.class));
 
+    // Mock TranslationResource dependencies
+    when(cqlConversionService.getTranslationResource(any())).thenReturn(translationResource);
+    when(translationResource.buildTranslator(any())).thenReturn(cqlTranslator);
+    when(translationResource.getLibraryManager()).thenReturn(libraryManager);
+    when(cqlTranslator.getTranslatedLibrary()).thenReturn(compiledLibrary);
+    when(cqlTranslator.getTranslatedLibraries()).thenReturn(new ConcurrentHashMap<>());
+    when(compiledLibrary.getIdentifier()).thenReturn(versionedIdentifier);
+    when(libraryManager.getCompiledLibraries()).thenReturn(new ConcurrentHashMap<>());
+    when(compiledLibrary.getLibrary()).thenReturn(elmLibrary);
+
+    // Mock Library internals
+    when(elmLibrary.getUsings()).thenReturn(usings);
+    when(usings.getDef()).thenReturn(java.util.List.of());
+    when(elmLibrary.getStatements()).thenReturn(statements);
+    when(statements.getDef()).thenReturn(java.util.List.of());
+    when(elmLibrary.getIncludes()).thenReturn(null);
+
     MadieLibrarySourceProvider.setCqlLibraryService(cqlLibraryService);
     org.hl7.fhir.r5.model.Library r5Library =
         effectiveDataRequirementService.getEffectiveDataRequirements(
@@ -107,7 +162,7 @@ class EffectiveDataRequirementServiceTest {
 
     String r5LibraryStr =
         effectiveDataRequirementService.getEffectiveDataRequirementsStr(r5Library);
-    assertEquals(r5LibraryStr, "test");
+    assertEquals("test", r5LibraryStr);
   }
 
   @Test
@@ -137,13 +192,28 @@ class EffectiveDataRequirementServiceTest {
         .when(cqlLibraryService)
         .getLibraryCql(eq("AHAOverall"), eq("2.8.000"), nullable(String.class));
 
+    // Mock TranslationResource dependencies
+    when(cqlConversionService.getTranslationResource(any())).thenReturn(translationResource);
+    when(translationResource.buildTranslator(any())).thenReturn(cqlTranslator);
+    when(translationResource.getLibraryManager()).thenReturn(libraryManager);
+    when(cqlTranslator.getTranslatedLibrary()).thenReturn(compiledLibrary);
+    when(cqlTranslator.getTranslatedLibraries()).thenReturn(new ConcurrentHashMap<>());
+    when(compiledLibrary.getIdentifier()).thenReturn(versionedIdentifier);
+    when(libraryManager.getCompiledLibraries()).thenReturn(new ConcurrentHashMap<>());
+    when(compiledLibrary.getLibrary()).thenReturn(elmLibrary);
+
+    // Mock Library internals
+    when(elmLibrary.getUsings()).thenReturn(usings);
+    when(usings.getDef()).thenReturn(java.util.List.of());
+    when(elmLibrary.getStatements()).thenReturn(statements);
+    when(statements.getDef()).thenReturn(java.util.List.of(expressionDef));
+    when(expressionDef.getName()).thenReturn("TestExpression");
+    when(elmLibrary.getIncludes()).thenReturn(null);
+
     MadieLibrarySourceProvider.setCqlLibraryService(cqlLibraryService);
     org.hl7.fhir.r5.model.Library r5Library =
         effectiveDataRequirementService.getEffectiveDataRequirements(
             cqlLibraryDetails, false, testAccessToken);
-    assertEquals(r5Library.getId(), "effective-data-requirements");
-    assertEquals(
-        "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
-        r5Library.getExtension().get(0).getUrl());
+    assertEquals("effective-data-requirements", r5Library.getId());
   }
 }


### PR DESCRIPTION
## CQL to ELM Translation Service PR

Jira Ticket: [MAT-9465](https://jira.cms.gov/browse/MAT-9465)
(Optional) Related Tickets:

### Summary
Update the EffectiveDataRequirementService to make use of CqlConversionService. This is to bring support for STU7+ to effective data requirements process in a reusable fashion.
This also brings in the latest translator-commons to eliminate the translation issues related to the fake singleton pattern of the TranslationResource class.


### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
