### PR TITLE
MAT-10057: update spring boot (from 3.5.14 to 4.0.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.14</version>
+    <version>4.0.6</version>
   </parent>
   <groupId>gov.cms.madie</groupId>
   <artifactId>cql-elm-translation</artifactId>
@@ -16,7 +16,6 @@
   <properties>
     <cqframework.version>4.8.0</cqframework.version>
     <hapi.fhir.version>8.10.0</hapi.fhir.version>
-    <jackson.version>2.21.2</jackson.version>
     <java.version>17</java.version>
     <mvn.checkstyle.file>madie-checkstyle.xml</mvn.checkstyle.file>
     <mvn.checkstyle.version>3.1.2</mvn.checkstyle.version>
@@ -78,6 +77,18 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security-oauth2-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -185,7 +196,7 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.8.10</version>
+      <version>3.0.3</version>
       <exclusions>
         <exclusion>
           <artifactId>jackson-core</artifactId>
@@ -216,7 +227,7 @@
     <dependency>
       <groupId>com.okta.spring</groupId>
       <artifactId>okta-spring-boot-starter</artifactId>
-      <version>3.0.7</version>
+      <version>3.1.0</version>
       <exclusions>
         <exclusion>
           <artifactId>spring-security-web</artifactId>
@@ -244,7 +255,7 @@
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-java-models</artifactId>
-      <version>0.9.0-SNAPSHOT</version>
+      <version>0.10.0-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <artifactId>jackson-core</artifactId>
@@ -264,22 +275,12 @@
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-translator-commons</artifactId>
-      <version>3.4.0</version>
+      <version>3.5.0</version>
     </dependency>
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-rest-commons</artifactId>
-      <version>1.0.6-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <version>1.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -314,7 +315,6 @@
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -330,6 +330,11 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-webmvc-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.7</version>
   </parent>
   <groupId>gov.cms.madie</groupId>
   <artifactId>cql-elm-translation</artifactId>

--- a/src/main/java/gov/cms/mat/cql_elm_translation/CqlElmTranslationApplication.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/CqlElmTranslationApplication.java
@@ -8,8 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
-import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.data.mongodb.autoconfigure.DataMongoAutoConfiguration;
+import org.springframework.boot.mongodb.autoconfigure.MongoAutoConfiguration;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -29,7 +29,7 @@ import jakarta.annotation.PostConstruct;
 
 import java.util.TimeZone;
 
-@SpringBootApplication(exclude = {MongoAutoConfiguration.class, MongoDataAutoConfiguration.class})
+@SpringBootApplication(exclude = {MongoAutoConfiguration.class, DataMongoAutoConfiguration.class})
 @Configuration
 @Slf4j
 @Import({CqlLibraryService.class, FhirUtil.class})

--- a/src/main/java/gov/cms/mat/cql_elm_translation/config/security/SecurityConfig.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/config/security/SecurityConfig.java
@@ -4,12 +4,15 @@ import gov.cms.mat.cql_elm_translation.clients.UserRoleConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
 
@@ -28,35 +31,26 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http, UserRoleConverter roleConverter)
       throws Exception {
 
-    http.cors()
-        .and()
-        .csrf()
-        .ignoringRequestMatchers(CSRF_WHITELIST)
-        .and()
-        .authorizeHttpRequests()
-        .requestMatchers(HttpMethod.PUT, "/mat/translator/cqlToElm/**")
-        .permitAll()
-        .requestMatchers(AUTH_WHITELIST)
-        .permitAll()
-        .and()
-        .authorizeHttpRequests()
-        .requestMatchers("/admin/**")
-        .hasRole("MADIE-ADMIN")
-        .anyRequest()
-        .authenticated()
-        .and()
-        .sessionManagement()
-        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        .and()
-        .oauth2ResourceServer()
-        .jwt()
-        .jwtAuthenticationConverter(roleConverter)
-        .and()
-        .and()
-        .headers()
-        .xssProtection()
-        .and()
-        .contentSecurityPolicy("script-src 'self'");
+    http.cors(Customizer.withDefaults())
+        .csrf(csrf -> csrf.ignoringRequestMatchers(CSRF_WHITELIST))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(HttpMethod.PUT, "/mat/translator/cqlToElm/**")
+                    .permitAll()
+                    .requestMatchers(AUTH_WHITELIST)
+                    .permitAll()
+                    .requestMatchers("/admin/**")
+                    .hasRole("MADIE-ADMIN")
+                    .anyRequest()
+                    .authenticated())
+        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .oauth2ResourceServer(
+            oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(roleConverter)))
+        .headers(
+            headers ->
+                headers
+                    .xssProtection(Customizer.withDefaults())
+                    .contentSecurityPolicy(csp -> csp.policyDirectives("script-src 'self'")));
 
     return http.build();
   }

--- a/src/main/java/gov/cms/mat/cql_elm_translation/config/security/UserServiceClientConfig.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/config/security/UserServiceClientConfig.java
@@ -1,21 +1,15 @@
 package gov.cms.mat.cql_elm_translation.config.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class UserServiceClientConfig {
 
   @Bean
-  public RestTemplate userServiceRestTemplate(ObjectMapper objectMapper) {
-    MappingJackson2HttpMessageConverter messageConverter =
-        new MappingJackson2HttpMessageConverter();
-    messageConverter.setObjectMapper(objectMapper);
-
-    return new RestTemplateBuilder().additionalMessageConverters(messageConverter).build();
+  public RestTemplate userServiceRestTemplate(RestTemplateBuilder builder) {
+    return builder.build();
   }
 }

--- a/src/main/java/gov/cms/mat/cql_elm_translation/controllers/CqlConversionController.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/controllers/CqlConversionController.java
@@ -1,9 +1,9 @@
 package gov.cms.mat.cql_elm_translation.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 import gov.cms.mat.cql.dto.CqlConversionPayload;
 import gov.cms.mat.cql_elm_translation.service.CqlConversionService;
 import gov.cms.madie.cql_elm_translator.utils.cql.data.RequestData;
@@ -20,9 +20,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Iterator;
-import java.util.Objects;
 
 @RestController
 @RequestMapping(path = "/cql/translator")
@@ -116,20 +115,16 @@ public class CqlConversionController {
 
         for (int i = 0; i < annotationNode.size(); i++) {
           // remove translator options that are not the version
-          if (annotationNode.get(i).has("translatorOptions")) {
-            Iterator<String> fieldNames = annotationNode.get(i).fieldNames();
-            while (fieldNames.hasNext()) {
-              if (!Objects.equals(fieldNames.next(), "translatorVersion")) {
-                fieldNames.remove();
-              }
-            }
+          if (annotationNode.get(i).has("translatorOptions")
+              && annotationNode.get(i) instanceof ObjectNode optionsNode) {
+            optionsNode.retain("translatorVersion");
           }
         }
 
         return rootNode.toPrettyString();
 
-      } catch (JsonProcessingException e) {
-        throw new UncheckedIOException(e);
+      } catch (JacksonException e) {
+        throw new UncheckedIOException(new IOException(e));
       }
     }
   }

--- a/src/main/java/gov/cms/mat/cql_elm_translation/service/support/CqlExceptionErrorProcessor.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/service/support/CqlExceptionErrorProcessor.java
@@ -1,9 +1,9 @@
 package gov.cms.mat.cql_elm_translation.service.support;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 import gov.cms.mat.fhir.rest.dto.MatCqlConversionException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -50,7 +50,7 @@ public class CqlExceptionErrorProcessor {
     }
   }
 
-  private String addErrorsToJson() throws JsonProcessingException {
+  private String addErrorsToJson() throws JacksonException {
     JsonNode rootNode = mapper.readTree(json);
 
     ObjectNode updatedNode = (ObjectNode) rootNode;

--- a/src/main/java/gov/cms/mat/cql_elm_translation/service/support/CqlExceptionErrorProcessor.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/service/support/CqlExceptionErrorProcessor.java
@@ -1,6 +1,5 @@
 package gov.cms.mat.cql_elm_translation.service.support;
 
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.ObjectNode;
@@ -50,7 +49,7 @@ public class CqlExceptionErrorProcessor {
     }
   }
 
-  private String addErrorsToJson() throws JacksonException {
+  private String addErrorsToJson() {
     JsonNode rootNode = mapper.readTree(json);
 
     ObjectNode updatedNode = (ObjectNode) rootNode;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,9 @@ cql-translator:
   version: @cqframework.version@
 
 spring:
+  jackson:
+    deserialization:
+      fail-on-null-for-primitives: false
   profiles:
     active: local
 

--- a/src/test/java/gov/cms/mat/cql_elm_translation/controllers/CqlConversionControllerTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/controllers/CqlConversionControllerTest.java
@@ -19,7 +19,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -108,7 +107,7 @@ class CqlConversionControllerTest implements ResourceFileUtil {
   }
 
   @Test
-  void translatorOptionsRemoverEmptyAnnotations() throws JacksonException {
+  void translatorOptionsRemoverEmptyAnnotations() {
 
     String json = getData("/fhir4_std_lib_empty_array_annotations.json");
 

--- a/src/test/java/gov/cms/mat/cql_elm_translation/controllers/CqlConversionControllerTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/controllers/CqlConversionControllerTest.java
@@ -19,10 +19,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import gov.cms.mat.cql.dto.CqlConversionPayload;
 import gov.cms.mat.cql_elm_translation.ResourceFileUtil;
@@ -109,8 +108,7 @@ class CqlConversionControllerTest implements ResourceFileUtil {
   }
 
   @Test
-  void translatorOptionsRemoverEmptyAnnotations()
-      throws JsonMappingException, JsonProcessingException {
+  void translatorOptionsRemoverEmptyAnnotations() throws JacksonException {
 
     String json = getData("/fhir4_std_lib_empty_array_annotations.json");
 

--- a/src/test/java/gov/cms/mat/cql_elm_translation/controllers/CqlToolsControllerMvcTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/controllers/CqlToolsControllerMvcTest.java
@@ -1,16 +1,20 @@
 package gov.cms.mat.cql_elm_translation.controllers;
 
 import gov.cms.madie.cql_elm_translator.dto.CqlBuilderLookup;
+import gov.cms.mat.cql_elm_translation.clients.UserRoleConverter;
 import gov.cms.mat.cql_elm_translation.clients.UserServiceClient;
+import gov.cms.mat.cql_elm_translation.config.security.SecurityConfig;
 import gov.cms.mat.cql_elm_translation.service.CqlParsingService;
 import gov.cms.mat.cql_elm_translation.service.DataCriteriaService;
 import org.apache.http.HttpStatus;
 import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -28,11 +32,13 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 
 @WebMvcTest({CqlToolsController.class})
+@Import({SecurityConfig.class, UserRoleConverter.class})
 public class CqlToolsControllerMvcTest {
   private static final String TEST_USER_ID = "john_doe";
   @MockitoBean private UserServiceClient userServiceClient;
   @MockitoBean private DataCriteriaService dataCriteriaService;
   @MockitoBean private CqlParsingService cqlParsingService;
+  @MockitoBean private JwtDecoder jwtDecoder;
 
   @Autowired private MockMvc mockMvc;
 

--- a/src/test/java/gov/cms/mat/cql_elm_translation/controllers/EffectiveDataRequirementControllerMVCTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/controllers/EffectiveDataRequirementControllerMVCTest.java
@@ -1,15 +1,18 @@
 package gov.cms.mat.cql_elm_translation.controllers;
 
 import gov.cms.madie.cql_elm_translator.dto.CqlLibraryDetails;
+import gov.cms.mat.cql_elm_translation.clients.UserRoleConverter;
 import gov.cms.mat.cql_elm_translation.clients.UserServiceClient;
+import gov.cms.mat.cql_elm_translation.config.security.SecurityConfig;
 import gov.cms.mat.cql_elm_translation.service.EffectiveDataRequirementService;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -20,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,6 +32,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({EffectiveDataRequirementController.class})
+@Import({SecurityConfig.class, UserRoleConverter.class})
 class EffectiveDataRequirementControllerMVCTest {
 
   private static final String TEST_USER_ID = "john_doe";
@@ -36,8 +41,9 @@ class EffectiveDataRequirementControllerMVCTest {
   @Autowired private MockMvc mockMvc;
 
   @MockitoBean EffectiveDataRequirementService effectiveDataRequirementService;
+  @MockitoBean private JwtDecoder jwtDecoder;
 
-  @Mock org.hl7.fhir.r5.model.Library r5Libray;
+  private final org.hl7.fhir.r5.model.Library r5Libray = mock(org.hl7.fhir.r5.model.Library.class);
 
   @Test
   public void testGetEffectiveDataRequirementsThrowsExceptionWhenLibraryDetailsIsnull()

--- a/src/test/java/gov/cms/mat/cql_elm_translation/controllers/ErrorHandlingControllerAdvice.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/controllers/ErrorHandlingControllerAdvice.java
@@ -3,7 +3,7 @@ package gov.cms.mat.cql_elm_translation.controllers;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
-import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.boot.webmvc.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/src/test/java/gov/cms/mat/cql_elm_translation/service/CqlConversionServicePropertyTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/service/CqlConversionServicePropertyTest.java
@@ -1,9 +1,9 @@
 package gov.cms.mat.cql_elm_translation.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
 import gov.cms.madie.cql_elm_translator.utils.FhirUtil;
 import gov.cms.mat.cql.dto.CqlConversionPayload;
 import gov.cms.mat.cql.elements.UsingProperties;
@@ -121,7 +121,7 @@ class CqlConversionServicePropertyTest implements ResourceFileUtil {
   }
 
   @Test
-  void testProcessCqlDataWithErrors() throws JsonProcessingException {
+  void testProcessCqlDataWithErrors() throws JacksonException {
     when(fhirUtil.getMinVersionForNpm(any(UsingProperties.class))).thenReturn("7.0.0");
     cqlData = getData("/cv_populations.cql");
     RequestData requestData = buildRequestData();

--- a/src/test/java/gov/cms/mat/cql_elm_translation/service/CqlConversionServicePropertyTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/service/CqlConversionServicePropertyTest.java
@@ -1,6 +1,5 @@
 package gov.cms.mat.cql_elm_translation.service;
 
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.ArrayNode;
@@ -121,7 +120,7 @@ class CqlConversionServicePropertyTest implements ResourceFileUtil {
   }
 
   @Test
-  void testProcessCqlDataWithErrors() throws JacksonException {
+  void testProcessCqlDataWithErrors() {
     when(fhirUtil.getMinVersionForNpm(any(UsingProperties.class))).thenReturn("7.0.0");
     cqlData = getData("/cv_populations.cql");
     RequestData requestData = buildRequestData();

--- a/src/test/java/gov/cms/mat/cql_elm_translation/service/CqlConversionServiceTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/service/CqlConversionServiceTest.java
@@ -1,8 +1,8 @@
 package gov.cms.mat.cql_elm_translation.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import gov.cms.madie.cql_elm_translator.utils.FhirUtil;
 import gov.cms.madie.models.dto.TranslatedLibrary;
 import gov.cms.mat.cql.CqlTextParser;
@@ -25,9 +25,10 @@ import org.hl7.elm.r1.Library;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestTemplate;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -60,7 +61,7 @@ import gov.cms.mat.cql.elements.UsingProperties;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest(properties = {"madie.ig-resource-pattern=classpath:igs/*.json"})
+@ExtendWith(MockitoExtension.class)
 class CqlConversionServiceTest implements ResourceFileUtil {
 
   @Mock RestTemplate restTemplate;
@@ -251,7 +252,7 @@ class CqlConversionServiceTest implements ResourceFileUtil {
           is(
               equalTo(
                   "FHIRHelpers is required as an included library for QI-Core. Please add the appropriate version of FHIRHelpers to your CQL.")));
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       fail(e.getMessage());
     }
   }
@@ -290,7 +291,7 @@ class CqlConversionServiceTest implements ResourceFileUtil {
               equalTo(
                   "FHIRHelpers is required as an included library for QI-Core. Please add the appropriate version of FHIRHelpers to your CQL.")));
 
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       fail(e.getMessage());
     }
   }
@@ -364,7 +365,7 @@ class CqlConversionServiceTest implements ResourceFileUtil {
             }
           });
       assertTrue(foundMessage.get());
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       fail(e.getMessage());
     }
   }
@@ -421,7 +422,7 @@ class CqlConversionServiceTest implements ResourceFileUtil {
           is(
               equalTo(
                   "Library SupplementalDataElements Version 4.0.000 is already in use in this library.")));
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       fail(e.getMessage());
     }
   }

--- a/src/test/java/gov/cms/mat/cql_elm_translation/service/CqlConversionServiceTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/service/CqlConversionServiceTest.java
@@ -1,6 +1,5 @@
 package gov.cms.mat.cql_elm_translation.service;
 
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import gov.cms.madie.cql_elm_translator.utils.FhirUtil;
@@ -239,22 +238,18 @@ class CqlConversionServiceTest implements ResourceFileUtil {
     assertNotNull(payload);
     String resultJson = payload.getJson();
     ObjectMapper objectMapper = new ObjectMapper();
-    try {
-      JsonNode jsonNode = objectMapper.readTree(resultJson);
-      assertNotNull(jsonNode);
+    JsonNode jsonNode = objectMapper.readTree(resultJson);
+    assertNotNull(jsonNode);
 
-      JsonNode libraryNodeEx = jsonNode.at("/errorExceptions");
-      assertNotNull(libraryNodeEx);
-      assertFalse(libraryNodeEx.isMissingNode());
-      assertThat(libraryNodeEx.isArray(), is(true));
-      assertThat(
-          libraryNodeEx.get(0).get("message").textValue(),
-          is(
-              equalTo(
-                  "FHIRHelpers is required as an included library for QI-Core. Please add the appropriate version of FHIRHelpers to your CQL.")));
-    } catch (JacksonException e) {
-      fail(e.getMessage());
-    }
+    JsonNode libraryNodeEx = jsonNode.at("/errorExceptions");
+    assertNotNull(libraryNodeEx);
+    assertFalse(libraryNodeEx.isMissingNode());
+    assertThat(libraryNodeEx.isArray(), is(true));
+    assertThat(
+        libraryNodeEx.get(0).get("message").textValue(),
+        is(
+            equalTo(
+                "FHIRHelpers is required as an included library for QI-Core. Please add the appropriate version of FHIRHelpers to your CQL.")));
   }
 
   @Test
@@ -277,23 +272,18 @@ class CqlConversionServiceTest implements ResourceFileUtil {
     assertNotNull(payload);
     String resultJson = payload.getJson();
     ObjectMapper objectMapper = new ObjectMapper();
-    try {
-      JsonNode jsonNode = objectMapper.readTree(resultJson);
-      assertNotNull(jsonNode);
+    JsonNode jsonNode = objectMapper.readTree(resultJson);
+    assertNotNull(jsonNode);
 
-      JsonNode libraryNodeEx = jsonNode.at("/errorExceptions");
-      assertNotNull(libraryNodeEx);
-      assertFalse(libraryNodeEx.isMissingNode());
-      assertThat(libraryNodeEx.isArray(), is(true));
-      assertThat(
-          libraryNodeEx.get(0).get("message").textValue(),
-          is(
-              equalTo(
-                  "FHIRHelpers is required as an included library for QI-Core. Please add the appropriate version of FHIRHelpers to your CQL.")));
-
-    } catch (JacksonException e) {
-      fail(e.getMessage());
-    }
+    JsonNode libraryNodeEx = jsonNode.at("/errorExceptions");
+    assertNotNull(libraryNodeEx);
+    assertFalse(libraryNodeEx.isMissingNode());
+    assertThat(libraryNodeEx.isArray(), is(true));
+    assertThat(
+        libraryNodeEx.get(0).get("message").textValue(),
+        is(
+            equalTo(
+                "FHIRHelpers is required as an included library for QI-Core. Please add the appropriate version of FHIRHelpers to your CQL.")));
   }
 
   @Test
@@ -346,28 +336,24 @@ class CqlConversionServiceTest implements ResourceFileUtil {
     assertNotNull(payload);
     String resultJson = payload.getJson();
     ObjectMapper objectMapper = new ObjectMapper();
-    try {
-      JsonNode jsonNode = objectMapper.readTree(resultJson);
-      assertNotNull(jsonNode);
+    JsonNode jsonNode = objectMapper.readTree(resultJson);
+    assertNotNull(jsonNode);
 
-      JsonNode libraryNodeEx = jsonNode.at("/errorExceptions");
-      assertNotNull(libraryNodeEx);
-      assertFalse(libraryNodeEx.isMissingNode());
-      assertThat(libraryNodeEx.isArray(), is(true));
+    JsonNode libraryNodeEx = jsonNode.at("/errorExceptions");
+    assertNotNull(libraryNodeEx);
+    assertFalse(libraryNodeEx.isMissingNode());
+    assertThat(libraryNodeEx.isArray(), is(true));
 
-      final AtomicBoolean foundMessage = new AtomicBoolean(false);
-      libraryNodeEx.forEach(
-          node -> {
-            if (node.get("message")
-                .asText()
-                .contains("Library SupplementalDataElements is already in use in this library.")) {
-              foundMessage.set(true);
-            }
-          });
-      assertTrue(foundMessage.get());
-    } catch (JacksonException e) {
-      fail(e.getMessage());
-    }
+    final AtomicBoolean foundMessage = new AtomicBoolean(false);
+    libraryNodeEx.forEach(
+        node -> {
+          if (node.get("message")
+              .asText()
+              .contains("Library SupplementalDataElements is already in use in this library.")) {
+            foundMessage.set(true);
+          }
+        });
+    assertTrue(foundMessage.get());
   }
 
   @Test
@@ -408,23 +394,19 @@ class CqlConversionServiceTest implements ResourceFileUtil {
     assertNotNull(payload);
     String resultJson = payload.getJson();
     ObjectMapper objectMapper = new ObjectMapper();
-    try {
-      JsonNode jsonNode = objectMapper.readTree(resultJson);
-      assertNotNull(jsonNode);
+    JsonNode jsonNode = objectMapper.readTree(resultJson);
+    assertNotNull(jsonNode);
 
-      JsonNode libraryNodeEx = jsonNode.at("/errorExceptions");
-      assertNotNull(libraryNodeEx);
-      assertFalse(libraryNodeEx.isMissingNode());
-      assertThat(libraryNodeEx.isArray(), is(true));
-      JsonNode finalNode = libraryNodeEx.get(libraryNodeEx.size() - 1);
-      assertThat(
-          finalNode.get("message").textValue(),
-          is(
-              equalTo(
-                  "Library SupplementalDataElements Version 4.0.000 is already in use in this library.")));
-    } catch (JacksonException e) {
-      fail(e.getMessage());
-    }
+    JsonNode libraryNodeEx = jsonNode.at("/errorExceptions");
+    assertNotNull(libraryNodeEx);
+    assertFalse(libraryNodeEx.isMissingNode());
+    assertThat(libraryNodeEx.isArray(), is(true));
+    JsonNode finalNode = libraryNodeEx.get(libraryNodeEx.size() - 1);
+    assertThat(
+        finalNode.get("message").textValue(),
+        is(
+            equalTo(
+                "Library SupplementalDataElements Version 4.0.000 is already in use in this library.")));
   }
 
   @Test

--- a/src/test/java/gov/cms/mat/cql_elm_translation/service/support/CqlExceptionErrorProcessorTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/service/support/CqlExceptionErrorProcessorTest.java
@@ -1,7 +1,7 @@
 package gov.cms.mat.cql_elm_translation.service.support;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import gov.cms.mat.cql_elm_translation.ResourceFileUtil;
 import org.cqframework.cql.cql2elm.CqlCompilerException;
 


### PR DESCRIPTION
## CQL to ELM Translation Service PR

Jira Ticket: [MAT-10057](https://jira.cms.gov/browse/MAT-10057)
(Optional) Related Tickets:

### Summary

# Spring Boot 4 + Jackson 3 Upgrade Notes — madie-fhir-elm-translator

Part of the fleet-wide SB 3.5.14 → 4.0.6 + Jackson 2 → 3 migration. Common patterns live in
`madie-fhir-service/SPRING_BOOT_4_UPGRADE.md`; this file records only what was specific to this repo.

Already on Spring Boot 4.0.6 from MAT-10056 but running Jackson 2 via a stop-gap. This change removes the
stop-gap and moves to Jackson 3.

## pom.xml
- Removed `spring-boot-jackson2`.
- Removed the explicit `com.fasterxml.jackson.core:jackson-core`/`jackson-databind` deps pinned to
  `${jackson.version}` (2.21.2) and the `jackson.version` property — Jackson 3 (`tools.jackson`) now comes
  from the parent BOM.
- Bumped pins: `madie-java-models` `0.9.0-SNAPSHOT` → `0.10.0-SNAPSHOT`; `madie-rest-commons`
  `1.0.6-SNAPSHOT` → `1.1.0-SNAPSHOT`; `madie-translator-commons` `3.4.0` → `3.5.0`.
- **springdoc `2.8.10` → `3.0.3`** (playbook §8) — springdoc 2.8.x is SB3-only (its `QuerydslPredicateOperationCustomizer`
  / Hateoas config reference Spring-6/spring-data-3 API shapes that SB4 relocated; symptom here was a startup
  `IllegalStateException → NoClassDefFoundError org.springframework.data.util.TypeInformation`, DEBUG-swallowed but
  noisy). springdoc 3.0.x targets SB4. Applied during the 2026-06-16 upstream sync (see below).
- Left the pre-existing Jackson-2-era `<exclusions>` on various starters — harmless under Jackson 3
  because core/databind moved to the `tools.jackson` group (different groupId), so those exclusions are
  now no-ops.

## application.yaml
- Removed `spring.http.converters.preferred-json-mapper: jackson2`.

## UserServiceClientConfig
- Removed the Jackson-2 converter surgery (`MappingJackson2HttpMessageConverter`); the bean is now
  `userServiceRestTemplate(RestTemplateBuilder builder) { return builder.build(); }`. SB4's default
  Jackson 3 converter honors the (now Jackson-3) `Version` serializers directly.

## Source — Jackson 3 API
- Package swaps to `tools.jackson.*`: `JsonNode`, `ObjectMapper`, `node.ObjectNode`/`node.ArrayNode`.
- `JsonProcessingException` (checked, removed) → `tools.jackson.core.JacksonException` (unchecked) in
  `CqlConversionController`, `CqlExceptionErrorProcessor`, and tests; `JsonMappingException` import dropped.
- **`CqlConversionController`** — two real API changes (not just packages):
  - `JsonNode.fieldNames()` is **gone** in Jackson 3. The old loop "remove every property except
    `translatorVersion`" became `((ObjectNode) node).retain("translatorVersion")`. Removed the now-unused
    `Iterator`/`Objects` imports.
  - The `catch` wrapped the parse error in `UncheckedIOException` (a test asserts that type). Jackson 3's
    `JacksonException` is a `RuntimeException`, **not** an `IOException`, so
    `new UncheckedIOException(e)` no longer compiles → `new UncheckedIOException(new IOException(e))`
    (added `java.io.IOException` import) to preserve the asserted behavior.

## Screening (per the full-guide checklist)
- The only custom `HttpMessageConverter` was `UserServiceClientConfig`, now removed — nothing to migrate to
  the new `Client/ServerHttpMessageConvertersCustomizer`.
- `org.springframework.lang.Nullable` usages still compile (deprecated, not removed) — left as-is.

## Upstream sync (2026-06-16)
Merged `origin/develop` (was 5 commits behind) into the SB4 branch via stash → pull → pop. Notable incoming
non-SB4 changes now in this branch's diff:
- **MAT-10029** parameterized IG loading. `ModelManagerFactory` now injects
  `@Value("${madie.ig-resource-pattern:classpath*:igs/*.json}") String igResourcePattern` and calls
  `ImplementationGuideLoader.load(igResourcePattern)` (the no-arg `load()` was removed in translator-commons 3.5.0).
  We **took the dev's `ModelManagerFactory`/`ModelManagerFactoryTest`** over our hardcoded SB4 stop-gap
  (`load("classpath*:igs/*.json")`) — the `@Value` default is the same glob, so the IGs loaded are identical
  (behavior-preserving). `CqlConversionServiceTest` kept `@ExtendWith(MockitoExtension.class)` (the ig-resource-pattern
  property is inert there since `modelManagerFactory` is `@Mock`; the property is really covered by `ModelManagerFactoryTest`).
- The dev **moved `FhirUtil.java`/`ModelNode.java` into translator-commons**; the local copies were deleted on pull
  (matches the 3.5.0 `FhirUtil`-constructor coupling on `CqlLibraryService`). Local `FhirUtilTest` deleted with them.
- Tests: 177 → **166** after this sync (dev deleted the local `FhirUtilTest`). Built against the rebuilt 3.5.0.
- (Note: terminology-service, the other `ImplementationGuideLoader` consumer, intentionally keeps the **hardcoded**
  `load("classpath*:igs/*.json")` rather than the `@Value` form — same runtime glob; see its `UPGRADE_NOTES.md`.)

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
